### PR TITLE
DateConverter: Fix two SpotBugs findings

### DIFF
--- a/net.sf.joptsimple/src/main/java/joptsimple/util/DateConverter.java
+++ b/net.sf.joptsimple/src/main/java/joptsimple/util/DateConverter.java
@@ -40,7 +40,7 @@ import joptsimple.internal.Messages;
  *
  * @author <a href="mailto:pholser@alumni.rice.edu">Paul Holser</a>
  */
-public class DateConverter implements ValueConverter<Date> {
+public final class DateConverter implements ValueConverter<Date> {
     private final DateFormat formatter;
 
     /**
@@ -53,7 +53,7 @@ public class DateConverter implements ValueConverter<Date> {
         if ( formatter == null )
             throw new NullPointerException( "illegal null formatter" );
 
-        this.formatter = formatter;
+        this.formatter = (DateFormat) formatter.clone();
     }
 
     /**


### PR DESCRIPTION
CT_CONSTRUCTOR_THROW: Make class final
to prevent  finalizer attacks.

EI_EXPOSE_REP2: Do not store an externally
mutable object, we create a copy.